### PR TITLE
make rpm install work

### DIFF
--- a/cmd/daemon/Dockerfile
+++ b/cmd/daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/busybox  
+FROM fedora:30
 COPY daemon /daemon
 RUN mkdir -p /etc/containers
 COPY policy.json /etc/containers/policy.json

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: kata-operator
           # Replace this with the built image name
-          image: quay.io/harpatil/kata-operator:0.1 
+          image: quay.io/jensfr/kata-operator:v1.0
           command:
           - kata-operator
           imagePullPolicy: Always


### PR DESCRIPTION
fix installrpms, change docker images, change path to crio conf,
include Harshal's fix for the content of crio dropin file, bail out of
installRPMs when file /usr/bin/kata-runtime is present on host
filesystem

Signed-off-by: Jens Freimann <jfreimann@redhat.com>