### PR TITLE
Fix pathes

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -19,7 +19,7 @@ The kata-operator is ready. Deploy a custom resource to start the installation
 See: deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml as an example
 To immediately start installation on all worker nodes just do
 
-  oc apply -f deploy/crds/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
+  oc apply -f deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
 
 EOF
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: kata-operator
           # Replace this with the built image name
-          image: quay.io/harpatil/kata-operator:0.1 
+          image: quay.io/isolatedcontainers/kata-operator:v1.0
           command:
           - kata-operator
           imagePullPolicy: Always

--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -238,7 +238,7 @@ func (r *ReconcileKataConfig) processDaemonsetForCR(operation DaemonOperation) *
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-install-pod",
-							Image:           "quay.io/harpatil/kata-install-daemon:1.5",
+							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:v1.0",
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,

--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -349,8 +349,7 @@ func (r *ReconcileKataConfig) newMCForCR() (*mcfgv1.MachineConfig, error) {
 	file.Filesystem = "root"
 	m := 420
 	file.Mode = &m
-	// file.Path = "/etc/crio/crio.conf.d/kata-50.conf"
-	file.Path = "/opt/kata-1.conf"
+	file.Path = "/etc/crio/crio.conf.d/kata-50.conf"
 
 	mc.Spec.Config.Storage.Files = []ignTypes.File{file}
 


### PR DESCRIPTION
This fixes the path to where the crio dropin file will be stored on the nodes.

It also fixes the path to the example CR in the deploy script that a user can copy/paste