### PR TITLE
travis: Build & upload the image using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+arch:
+  - amd64
+  - ppc64le
+  - s390x
+os: linux
+dist: bionic
+language: generic
+services:
+  - docker
+before_install:
+  - sudo chmod 755 /etc/docker
+
+  # Download and install operator-sdk (ADM64)
+  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-x86_64-linux-gnu
+  - sudo mv operator-sdk-v0.18.2-x86_64-linux-gnu /usr/local/bin/operator-sdk-amd64
+  - sudo chmod +x /usr/local/bin//operator-sdk-amd64
+  # Download and install a new enough version of go (AMD64)
+  - sudo wget https://golang.org/dl/go1.14.4.linux-amd64.tar.gz
+  - sudo mkdir /usr/local/amd64/
+  - sudo tar -C /usr/local/amd64 -xvzf go1.14.4.linux-amd64.tar.gz
+
+  # Download and install operator-sdk (PPC64LE)
+  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-ppc64le-linux-gnu
+  - sudo mv operator-sdk-v0.18.2-ppc64le-linux-gnu /usr/local/bin//operator-sdk-ppc64le
+  - sudo chmod +x /usr/local/bin//operator-sdk-ppc64le
+  # Download and install a new enough version of go (PPC64LE)
+  - sudo wget https://golang.org/dl/go1.14.4.linux-ppc64le.tar.gz
+  - sudo mkdir /usr/local/ppc64le/
+  - sudo tar -C /usr/local/ppc64le -xvzf go1.14.4.linux-ppc64le.tar.gz
+
+  # Download and install operator-sdk (s390x)
+  - sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-s390x-linux-gnu
+  - sudo mv operator-sdk-v0.18.2-s390x-linux-gnu /usr/local/bin//operator-sdk-s390x
+  - sudo chmod +x /usr/local/bin//operator-sdk-s390x
+  # Download and install a new enough version of go (s390x)
+  - sudo wget https://golang.org/dl/go1.14.4.linux-s390x.tar.gz
+  - sudo mkdir /usr/local/s390x/
+  - sudo tar -C /usr/local/s390x -xvzf go1.14.4.linux-s390x.tar.gz
+
+stages:
+  - deploy
+  - deploy-multi-arch
+
+jobs:
+  include:
+
+  # Build and push the image for amd64
+  - stage: deploy
+    name: Build image for kata-operator-daemon (amd64)
+    arch: amd64
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  # Build and push the image for ppc64le
+  - stage: deploy
+    name: Build image for kata-operator-daemon (ppc64le)
+    arch: ppc64le
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  # Build and push the image for s390x
+  - stage: deploy
+    name: Build image for kata-operator-daemon (s390x)
+    arch: s390x
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  - stage: deploy-multi-arch
+    name: Deploy multi-arch manifest
+    deploy:
+      provider: script
+      script: bash hack/deploy-multi-arch.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$

--- a/hack/deploy-multi-arch.sh
+++ b/hack/deploy-multi-arch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -xe
+
+IMAGE_NAME="quay.io/isolatedcontainers/kata-operator"
+
+if "${TRAVIS_BRANCH}" == "master"; then
+	TAG="latest"
+else
+	TAG="$(echo ${TRAVIS_BRANCH} | awk '{print $2}' FS='-')"
+fi
+
+docker login \
+	--username="${QUAY_USERNAME}" \
+	--password="${QUAY_PASSWORD}" \
+	quay.io
+
+env DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest create \
+	$IMAGE_NAME:$TAG \
+	$IMAGE_NAME:$TAG-amd64 \
+	$IMAGE_NAME:$TAG-ppc64le \
+	$IMAGE_NAME:$TAG-s390x
+
+env DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest push \
+	--purge \
+	$IMAGE_NAME:$TAG

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -xe
+
+IMAGE_NAME="quay.io/isolatedcontainers/kata-operator"
+
+if "${TRAVIS_BRANCH}" == "master"; then
+	TAG="latest-${TRAVIS_CPU_ARCH}"
+else
+	TAG="$(echo ${TRAVIS_BRANCH} | awk '{print $2}' FS='-')-${TRAVIS_CPU_ARCH}"
+fi
+
+# This is needed as even on a generic env, a really old version of
+# go is installed (but only on AMD64).
+export GOROOT=/usr/local/${TRAVIS_CPU_ARCH}/go
+export PATH=${GOROOT}/bin:$PATH
+export GOTOOLDIR=${GOROOT}/pkg/tool/linux_${TRAVIS_CPU_ARCH}
+
+docker login \
+	--username="${QUAY_USERNAME}" \
+	--password="${QUAY_PASSWORD}" \
+	quay.io
+
+operator-sdk-${TRAVIS_CPU_ARCH} build "${IMAGE_NAME}:${TAG}"
+
+docker push "${IMAGE_NAME}:${TAG}"


### PR DESCRIPTION
Let's automate the process of building and uploading the image to
quay.io.

This commit requires a some configurations done beforehand such as:
- Travis CI must be enabled by the owner of the repo;
- QUAY_USERNAME and QUAY_PASSWORD must be set, as secrets, on Travis CI
  side;

And also an agreement about the branches naming that will be adopted and
will be used as basis for the image name, such as:
- ocp-x.y for the images that should be used together with OCP x.y,
  generating images named "x.y-$arch";
- master will generate images names "latest-$arch";
- any other branch name will not trigger Travis CI;