### PR TITLE
By default install on all worker nodes

### DIFF
--- a/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
+++ b/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: kataconfiguration.openshift.io/v1alpha1
 kind: KataConfig
 metadata:
   name: example-kataconfig 
-spec:
-  kataConfigPoolSelector:
-    matchLabels:
-       custom-kata1: test 
+#spec:
+#  kataConfigPoolSelector:
+#    matchLabels:
+#       custom-kata1: test 


### PR DESCRIPTION
Change the kataconfig example CR so that it will install on all worker nodes by default