### PR TITLE
add scc for operator namespace to service account

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,6 +18,7 @@ oc apply -f deploy/role.yaml
 oc apply -f deploy/role_binding.yaml
 oc apply -f deploy/service_account.yaml
 oc adm policy add-scc-to-user privileged -z kata-operator
+oc adm policy add-scc-to-user privileged -z kata-operator -n kata-operator
 
 oc apply -f deploy/crds/kataconfiguration.openshift.io_kataconfigs_crd.yaml
 oc create -f deploy/operator.yaml


### PR DESCRIPTION
This is required to give the service account the access rights to run the installer pods in the kata-operator namespace

Signed-off-by: Jens Freimann <jfreimann@redhat.com>