### PR TITLE
Fix list kata pods check

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,6 +18,7 @@ oc apply -f deploy/role.yaml
 oc apply -f deploy/role_binding.yaml
 oc apply -f deploy/service_account.yaml
 oc adm policy add-scc-to-user privileged -z kata-operator
+oc adm policy add-scc-to-user privileged -z kata-operator -n kata-operator
 
 oc apply -f deploy/crds/kataconfiguration.openshift.io_kataconfigs_crd.yaml
 oc create -f deploy/operator.yaml

--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -454,8 +454,10 @@ func (r *ReconcileKataConfig) listKataPods() error {
 		return fmt.Errorf("Failed to list kata pods: %v", err)
 	}
 	for _, pod := range podList.Items {
-		if pod.Spec.RuntimeClassName == &r.kataConfig.Status.RuntimeClass {
-			return fmt.Errorf("Existing pods using Kata Runtime found. Please delete the pods manually for KataConfig deletion to proceed")
+		if pod.Spec.RuntimeClassName != nil {
+			if *pod.Spec.RuntimeClassName == r.kataConfig.Status.RuntimeClass {
+				return fmt.Errorf("Existing pods using Kata Runtime found. Please delete the pods manually for KataConfig deletion to proceed")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
When we uninstall we check for running pods that still use kata-runtime.
If yes we ask the user to delete these pods before the uninstall
procedure continues.
    
There was a bug in the if condition that checked the RuntimeClass. In
the pod spec the RuntimeClassName is a reference (pointer) to a string
while in Kataconfig RuntimeClass is a string. The comparison was done
between two pointers not the string values of the runtime class name.
    
Fix this by 1. checkinf if the pointer in pod.spec is set and 2.
changing the if condition to de-reference the string in
pod.spec.RuntimeClassName and compare it to the one in Kataconfig.
    
Signed-off-by: Jens Freimann <jfreimann@redhat.com>