### PR TITLE
Change filename of crio dropin config file

### DIFF
--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -367,7 +367,7 @@ WantedBy=multi-user.target
 	file.Filesystem = "root"
 	m := 420
 	file.Mode = &m
-	file.Path = "/etc/crio/crio.conf.d/kata-50.conf"
+	file.Path = "/etc/crio/crio.conf.d/50-kata.conf"
 
 	mc.Spec.Config.Storage.Files = []ignTypes.File{file}
 


### PR DESCRIPTION
Change the filename to comply with convention.

Fixes issue #33 

Reported-by: Andreas Karis <ak.karis@gmail.com>
Signed-off-by: Jens Freimann <jfreimann@redhat.com>