### PR TITLE
use correct path to kata-osbuilder.sh

### DIFF
--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -313,8 +313,8 @@ Description=Hacky service to enable kata-osbuilder-generate.service
 ConditionPathExists=/usr/lib/systemd/system/kata-osbuilder-generate.service
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/kata-containers/osbuilder/fedora-kata-osbuilder.sh
-ExecRestart=/usr/libexec/kata-containers/osbuilder/fedora-kata-osbuilder.sh
+ExecStart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
+ExecRestart=/usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
 [Install]
 WantedBy=multi-user.target
 `


### PR DESCRIPTION
For now we only support RH CoreOS as OS on the worker nodes, if we want to support fedora or others we'll need to make sure to call the correct script. But for new let's always use kata-osbuilder.sh.

Fixes issue #38 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>